### PR TITLE
README: use venv module on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 ## Installing on Linux
-Make sure that you have virtualenv installed. To do this on RHEL & Fedora run:
-```
-sudo yum install python3-virtualenv
-```
 Create a python virtual environments and then activate it:
 ```
-virtualenv venv
+python3 -m venv venv
 . venv/bin/activate
 ```
 Install the dependencies in requirements.txt in the virtual environment:


### PR DESCRIPTION
Python 3.3 includes the venv module in the standard library, so it's simpler to use that.