### PR TITLE
add RH IT CA instructions for MacOS

### DIFF
--- a/brew-client.md
+++ b/brew-client.md
@@ -53,8 +53,21 @@ topurl = http://download.devel.redhat.com/brewroot
 use_fast_upload = yes
 anon_retry = yes
 ```
-
 (This is a copy of `brewkoji.conf` from the `brewkoji` RPM.)
+
+4. Download Red Hat's IT CA to your local `.koji` config directory:
+
+   ```
+   curl https://password.corp.redhat.com/RH-IT-Root-CA.crt -o ~/.koji/RH-IT-Root-CA.crt
+   ```
+
+5. Export an environment variable that tells python-requests to trust this CA:
+
+   ```
+   export REQUESTS_CA_BUNDLE=$HOME/.koji/RH-IT-Root-CA.crt
+   ```
+   You'll need to export this environment variable every time you open a new
+   shell to run `koji` or the associated Python scripts in your virtualenv.
 
 ### Testing
 


### PR DESCRIPTION
Add instructions for MacOS developers to download Red Hat's IT CA and trust it for python-requests connections.

On Linux, the python-requests RPM uses the system-wide certificate store. When Linux users trust the Red Hat IT CA system-wide, then the non-virtualenv Python also trusts it seamlessly.

In virtualenvs however, python-requests defaults to trusting a bundle of certificates from the the https://pypi.org/project/certifi/ library. certifi only includes public CAs, not Red Hat's internal CA, so we must override that explicitly.