### PR TITLE
Non zero exit if channel validation fails

### DIFF
--- a/channel_validator.py
+++ b/channel_validator.py
@@ -82,14 +82,18 @@ class Channel:
             for host in group:
                 try:
                     if host.hw_dict["CPU(s)"] < self.min_cpus:
-                        print(f"in is_valid host: {host.id} has {host.hw_dict['CPU(s)']} CPU(s)")
+                        print(
+                            f"in is_valid host: {host.id} has {host.hw_dict['CPU(s)']} CPU(s)"
+                        )
                         flag = False
                 except TypeError:
-                    print(f"TypeError while checking CPU(s) of host: {host.id}\n Cannot compare {type(host.hw_dict['CPU(s)'])} to Int")
+                    print(
+                        f"TypeError while checking CPU(s) of host: {host.id}\n Cannot compare {type(host.hw_dict['CPU(s)'])} to Int"
+                    )
                     flag = False
 
         return flag
-                
+
 
 class Host:
     """
@@ -311,9 +315,6 @@ if __name__ == "__main__":
 
     rhel8_beefy.config_check()
 
-    if rhel8_beefy.is_valid():
-        exit(0)
-    
     print(f"rhel8_beefy contains {len(rhel8_beefy.host_list)} hosts")
     print(
         f"rhel8_beefy was divided in to {len(rhel8_beefy.config_groups)} configuration groups based on CPU count and Ram"
@@ -326,5 +327,8 @@ if __name__ == "__main__":
             print(
                 f"ID: {hosts.id} arches: {hosts.hw_dict['arches']} CPU(s): {hosts.hw_dict['CPU(s)']} Ram: {hosts.hw_dict['Ram']} Disk: {hosts.hw_dict['Disk']} Kernel: {hosts.hw_dict['Kernel']} O/S: {hosts.hw_dict['Operating System']}"
             )
+
+    if rhel8_beefy.is_valid():
+        exit(0)
 
     exit(1)

--- a/channel_validator.py
+++ b/channel_validator.py
@@ -12,11 +12,12 @@ class Channel:
     Brew build channel
     """
 
-    def __init__(self, name, id):
+    def __init__(self, name, id, cpus=8):
         self.name = str(name)
         self.id = int(id)
         self.host_list = []
         self.config_groups = []
+        self.min_cpus = cpus
 
     def __str__(self):
         """
@@ -72,6 +73,23 @@ class Channel:
 
         self.config_groups = config_groupings
 
+    def is_valid(self):
+        """
+        Checks that all hosts in self.config_groups has a valid cpu count
+        """
+        flag = True
+        for group in self.config_groups:
+            for host in group:
+                try:
+                    if host.hw_dict["CPU(s)"] < self.min_cpus:
+                        print(f"in is_valid host: {host.id} has {host.hw_dict['CPU(s)']} CPU(s)")
+                        flag = False
+                except TypeError:
+                    print(f"TypeError while checking CPU(s) of host: {host.id}\n Cannot compare {type(host.hw_dict['CPU(s)'])} to Int")
+                    flag = False
+
+        return flag
+                
 
 class Host:
     """
@@ -293,6 +311,9 @@ if __name__ == "__main__":
 
     rhel8_beefy.config_check()
 
+    if rhel8_beefy.is_valid():
+        exit(0)
+    
     print(f"rhel8_beefy contains {len(rhel8_beefy.host_list)} hosts")
     print(
         f"rhel8_beefy was divided in to {len(rhel8_beefy.config_groups)} configuration groups based on CPU count and Ram"
@@ -305,3 +326,5 @@ if __name__ == "__main__":
             print(
                 f"ID: {hosts.id} arches: {hosts.hw_dict['arches']} CPU(s): {hosts.hw_dict['CPU(s)']} Ram: {hosts.hw_dict['Ram']} Disk: {hosts.hw_dict['Disk']} Kernel: {hosts.hw_dict['Kernel']} O/S: {hosts.hw_dict['Operating System']}"
             )
+
+    exit(1)

--- a/channel_validator.py
+++ b/channel_validator.py
@@ -83,7 +83,7 @@ class Channel:
                 try:
                     if host.hw_dict["CPU(s)"] < self.min_cpus:
                         print(
-                            f"in is_valid host: {host.id} has {host.hw_dict['CPU(s)']} CPU(s)" # draw attention to valid hosts with less than 8 (minimum) CPUs 
+                            f"in is_valid host: {host.id} has {host.hw_dict['CPU(s)']} CPU(s)"  # draw attention to valid hosts with less than 8 (minimum) CPUs
                         )
                         flag = False
                 except TypeError:

--- a/channel_validator.py
+++ b/channel_validator.py
@@ -83,7 +83,7 @@ class Channel:
                 try:
                     if host.hw_dict["CPU(s)"] < self.min_cpus:
                         print(
-                            f"in is_valid host: {host.id} has {host.hw_dict['CPU(s)']} CPU(s)"
+                            f"in is_valid host: {host.id} has {host.hw_dict['CPU(s)']} CPU(s)" # draw attention to valid hosts with less than 8 (minimum) CPUs 
                         )
                         flag = False
                 except TypeError:


### PR DESCRIPTION
This PR adds a non zero exit when a channel fails to validate.

Changes made in this PR:
- min_cpus attribute added the the Channel class. The default value is 8.
- is_valid method added to Channel class. This checks all hosts in the channel have >= min_cpus.
- added exit(0) if the channel is valid, and exit(1) if the channel is not valid.